### PR TITLE
Changed the "|" to a "/" in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,8 @@
 I wrote this little check-script for nrpe/nagios to get the status of various raids in a box, and output the failed volumes if any such exist.
 
 ## Syntax
-``$path/check_smartarray.sh [email] [email]``
+``$path/check_smartarray.sh``
 
-If no arguments are specified, the script will assume its run for NRPE.
-If one or more email addresses are specified, the script will send an email in case an array reports an error.
 ## Output Examples
 | output | description |
 |--|--|

--- a/check_smartarray.sh
+++ b/check_smartarray.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # NRPE check for Proliant SmartArray Controllers (ciss)
 # Written by: Søren Klintrup <soren at klintrup.dk>
-# version 1.4.1
+# version 1.4.2
 
 PATH="/sbin:/bin:/usr/sbin:/usr/bin"
 DEVICES="$(camcontrol devlist|grep "COMPAQ RAID"|sed -Ee 's/.*(pass[0-9]{1,3}).*/\1/')"
@@ -15,37 +15,38 @@ do
  DEVICESTRING="$(camcontrol inquiry ${DEVICE} -D|sed -n -e 's/^[^<]*<\([^>]*\)>.*$/\1/p')"
  if [ "$(echo ${DEVICESTRING}|tr A-Z a-z|sed -Ee 's/.*(rea|int|rec|fai|ok).*/\1/')" = "" ]
  then
-  ERRORSTRING="${ERRORSTRING} | ${DEVICENAME}: unknown state"
+  ERRORSTRING="${ERRORSTRING} / ${DEVICENAME}: unknown state"
   if ! [ "${ERR}" = 2 ];then ERR=3;fi
  else
   case $(echo ${DEVICESTRING}|tr A-Z a-z|sed -Ee 's/.*(rea|int|rec|fai|ok).*/\1/') in
    int)
     ERR=2
-    ERRORSTRING="${ERRORSTRING} | ${DEVICENAME}: DEGRADED"
+    ERRORSTRING="${ERRORSTRING} / ${DEVICENAME}: DEGRADED"
     ;;
    fai)
     ERR=2
-    ERRORSTRING="${ERRORSTRING} | ${DEVICENAME}: FAILED"
+    ERRORSTRING="${ERRORSTRING} / ${DEVICENAME}: FAILED"
     ;;
    rec)
     if ! [ "${ERR}" = 2 -o "${ERR}" = 3 ]; then ERR=1;fi
-    ERRORSTRING="${ERRORSTRING} | ${DEVICENAME}: rebuilding"
+    ERRORSTRING="${ERRORSTRING} / ${DEVICENAME}: rebuilding"
     ;;
    rea)
     if ! [ "${ERR}" = 2 -o "${ERR}" = 3 ]; then ERR=1;fi
-    ERRORSTRING="${ERRORSTRING} | ${DEVICENAME}: ready for recovery"
+    ERRORSTRING="${ERRORSTRING} / ${DEVICENAME}: ready for recovery"
     ;;
    ok)
-    OKSTRING="${OKSTRING} | ${DEVICENAME}: ok"
+    OKSTRING="${OKSTRING} / ${DEVICENAME}: ok"
     ;;
    esac
  fi
 done
 if [ "${ERRORSTRING}" -o "${OKSTRING}" ]
 then
- echo ${ERRORSTRING} ${OKSTRING}|sed s/"^| "//
+ echo ${ERRORSTRING} ${OKSTRING}|sed s/"^\/ "//
  exit ${ERR}
 else
  echo no raid volumes found
  exit 3
 fi
+


### PR DESCRIPTION
The nagios web interface would only show one RAID volume, it seems nagios blocks "|" in the input and throws everything after that away.

Changed the "|" to a "/"

Thanks to Kai Gallasch for reporting this
