### PR TITLE
update syntax check to shared action

### DIFF
--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -7,12 +7,11 @@ permissions:
 
 jobs:
   sh:
-    name: sh-noexec-verify
+    name: simple-shell-syntax-check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run ShellCheck
-        run: sh -n check_smartarray.sh
+      - uses: Klintrup/simple-shell-syntax-check@v1
   shellcheck:
     name: shellcheck
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a change to the workflow file `.github/workflows/lint-shell.yml` to improve the naming and execution of a job. The `sh-noexec-verify` job was renamed to `simple-shell-syntax-check` and the `run` command was replaced with the `uses` command to run the `Klintrup/simple-shell-syntax-check@v1` action.

Main workflow change:

* <a href="diffhunk://#diff-cb01ce593de6f1d1a9c247dde8298db8c7210be7d0654e00597dd13c8e0e565eL10-R14">`.github/workflows/lint-shell.yml`</a>: Renamed the `sh-noexec-verify` job to `simple-shell-syntax-check` and replaced the `run` command with the `uses` command to run the `Klintrup/simple-shell-syntax-check@v1` action.