### PR TITLE
Add CODEOWNERS file with @Klintrup as the owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Klintrup


### PR DESCRIPTION
This pull request includes a single change to the `.github/CODEOWNERS` file, which adds `Klintrup` as the code owner for all files in the repository. This change designates `Klintrup` as responsible for reviewing and approving code changes.

* <a href="diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1">`.github/CODEOWNERS`</a>: Added `Klintrup` as the code owner for all files in the repository.