### PR TITLE
Update MegaLinter and checkout action versions for consistency

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -26,7 +26,7 @@
         pull-requests: write
       steps:
         - name: Checkout Code
-          uses: actions/checkout@v5
+          uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
           with:
             token: ${{ secrets.GITHUB_TOKEN }}
             fetch-depth: 0 # If you use VALIDATE_ALL_CODEBASE = true, you can remove this line to improve performances
@@ -36,7 +36,7 @@
           id: ml
           # You can override MegaLinter flavor used to have faster performances
           # More info at https://megalinter.io/flavors/
-          uses: oxsecurity/megalinter/flavors/documentation@v9
+          uses: oxsecurity/megalinter/flavors/documentation@0dcbedd66ea456ba2d54fd350affaa15df8a0da3 # v9.0.1
           env:
             # All available variables are described in documentation
             # https://megalinter.io/configuration/


### PR DESCRIPTION
This pull request updates dependencies in the `.github/workflows/megalinter.yml` workflow file to use specific commit hashes for improved reliability and traceability.

Dependency updates:

* Updated the `actions/checkout` step to reference a specific commit hash (`08c6903cd8c0fde910a37f88322edcfb5dd907a8`) for version 5.0.0, instead of the generic `@v5` tag.
* Updated the `oxsecurity/megalinter/flavors/documentation` action to reference a specific commit hash (`0dcbedd66ea456ba2d54fd350affaa15df8a0da3`) for version 9.0.1, instead of the generic `@v9` tag.